### PR TITLE
Update Flim-Flam blacklist in OpenBlocks.cfg

### DIFF
--- a/config/OpenBlocks.cfg
+++ b/config/OpenBlocks.cfg
@@ -327,6 +327,7 @@ tomfoolery {
 
     # Blacklist for effects used by flim-flam enchantment
     S:flimFlamBlacklist <
+        "creepers"
      >
 
     # Allow only flimflams that don't cause death (or at least very rarely)


### PR DESCRIPTION
Disabled Charged Creeper Flim-Flam event due to inter-mod interactions causing them to cause terrain damage when they shouldn't.