### PR TITLE
Tile entity setting for the builder, required for GT ores

### DIFF
--- a/config/rftools/main.cfg
+++ b/config/rftools/main.cfg
@@ -1468,7 +1468,7 @@ spaceprojector {
     I:quarryInfusionSpeedFactor=20
 
     # If true the quarry will skip all tile entities. Set this to false to allow harvesting ores that are tile entities. Be careful with this!
-    B:quarrySkipTileEntities=true
+    B:quarrySkipTileEntities=false
 
     # If true we allow shape cards to be crafted. Note that in order to use the quarry system you must also enable this
     B:shapeCardAllowed=true


### PR DESCRIPTION
due to the TE nature of GT ores this setting needs to be set to false to allow the RF tools quarry to mine these ores.